### PR TITLE
Crash when using this together with MQTT plugin

### DIFF
--- a/src/rabbit_auth_backend_amqp.erl
+++ b/src/rabbit_auth_backend_amqp.erl
@@ -257,7 +257,8 @@ table_row({K, V}) ->
     {bin(K), longstr, bin(V)}.
 
 bin(A) when is_atom(A)   -> list_to_binary(atom_to_list(A));
-bin(B) when is_binary(B) -> B.
+bin(B) when is_binary(B) -> B;
+bin(C) when is_list(C) -> list_to_binary(C).
 
 %%--------------------------------------------------------------------
 


### PR DESCRIPTION
The crash was due:

** Reason for termination == 
** {function_clause,
       [{rabbit_auth_backend_amqp,bin,
            ["v1/0eafa020-c164-11e6-b9c8-1baa7bae7f9d/things/7b925600-3762-11e7-be1b-318e6dea1212/cmd/+"],
            [{file,"src/rabbit_auth_backend_amqp.erl"},{line,220}]},
        {rabbit_auth_backend_amqp,table_row,1,
            [{file,"src/rabbit_auth_backend_amqp.erl"},{line,218}]},
        {rabbit_auth_backend_amqp,'-table/1-lc$^0/1-0-',1,
            [{file,"src/rabbit_auth_backend_amqp.erl"},{line,215}]},
        {rabbit_auth_backend_amqp,'-table/1-lc$^0/1-0-',1,
            [{file,"src/rabbit_auth_backend_amqp.erl"},{line,215}]},
        {rabbit_auth_backend_amqp,rpc,2,
            [{file,"src/rabbit_auth_backend_amqp.erl"},{line,173}]},
        {rabbit_auth_backend_amqp,bool_rpc,2,
            [{file,"src/rabbit_auth_backend_amqp.erl"},{line,205}]},
        {rabbit_auth_backend_amqp,handle_call,3,
            [{file,"src/rabbit_auth_backend_amqp.erl"},{line,123}]},
        {gen_server,try_handle_call,4,[{file,"gen_server.erl"},{line,636}]}]}
** Client <0.1796.0> stacktrace